### PR TITLE
License header: set excluded file patterns as not required

### DIFF
--- a/license-header-check/action.yml
+++ b/license-header-check/action.yml
@@ -21,7 +21,7 @@ inputs:
     type: string
   excluded_file_patterns:
     description: "excluded file pattern"
-    required: true
+    required: false
     type: string
 
 runs:


### PR DESCRIPTION
Set `excluded_file_patterns` as not required, as some repos need included patterns only.