### PR TITLE
License-header-check: ignore case matching

### DIFF
--- a/license-header-check/action.yml
+++ b/license-header-check/action.yml
@@ -68,7 +68,7 @@ runs:
           done
           if [[ $INCLUDE == true && $EXCLUDE == false ]]; then
             echo "Checking $FILE"
-            if !(grep -Eq "$LICENSE_PATTERN" "$FILE"); then
+            if !(grep -Eiq "$LICENSE_PATTERN" "$FILE"); then
               NO_LICENSE_FILES+="$FILE "
             fi
           fi


### PR DESCRIPTION
ignore case matching for copyright pattern. 

For the case like https://github.com/NVIDIA/spark-rapids-ml/blob/branch-24.12/python/benchmark/gen_data_distributed.py#L2