### PR TITLE
Add common add-to-project action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Add new issues and pull requests to project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  Add-to-project:
+    if: github.repository_owner == 'NVIDIA' # avoid adding issues from forks
+    runs-on: ubuntu-latest
+    steps:
+      - name: add-to-project
+        uses: NVIDIA/spark-rapids-common/add-to-project@main
+        with:
+          token: ${{ secrets.PROJECT_TOKEN }}

--- a/add-to-project/README.md
+++ b/add-to-project/README.md
@@ -1,0 +1,23 @@
+# add-to-project
+
+This composite action to add new issue and pull request to the project.
+
+## Inputs
+
+- `token` (required): GitHub token that has write access to the project
+
+## Usage
+
+```yaml
+jobs:
+  Add-to-project:
+    # ...
+    if: github.repository_owner == 'NVIDIA' # (optional)
+    steps:
+    # ...
+      - name: add-to-project
+        uses: NVIDIA/spark-rapids-common/add-to-project@main
+        with:
+          token: ${{ secrets.PROJECT_TOKEN }}
+    # ...
+```

--- a/add-to-project/action.yml
+++ b/add-to-project/action.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Add to Project"
+description: "Add new issue or pull request to the project"
+inputs:
+  token:
+    description: "GitHub token"
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Adding to project
+      uses: actions/add-to-project@v1.0.2
+      with:
+        project-url: https://github.com/orgs/NVIDIA/projects/4
+        github-token: ${{ inputs.token }}


### PR DESCRIPTION
fix #22 

1. Add reusable action for all spark-rapids repos so we can control the action version in one place, and will refactor workflow files separately
2. Add workflow check for common repo

verified in forks:
same repo:https://github.com/pxLi/spark-rapids-common/actions/runs/12879083900/job/35906018827
cross repos:https://github.com/pxLi/spark-rapids-jni/actions/runs/12879120694/job/35906114214

I will verify the actual usage after applying to `NVIDIA/*` repos