### PR TITLE
Add deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # spark-rapids-common
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVIDIA/spark-rapids-common)
+
 ## Introduction
 
 This repository contains reusable GitHub Action workflows and common scripts used by Spark RAPIDS.


### PR DESCRIPTION
introduce the deepwiki for common repo to enable weekly upgrade

<img width="550" alt="image" src="https://github.com/user-attachments/assets/78229ee9-4473-4fa6-9077-78b9ca34ae03" />
