### PR TITLE
custom markdown list check action

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   markdown-link-check:
+    permissions:
+        actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow to check markdown links
+name: markdown link check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: NVIDIA/spark-rapids-common/checkout@main
+
+      - name: Run Markdown Link Check
+        uses: NVIDIA/spark-rapids-common/markdown-link-check@main

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -31,23 +31,27 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        grep -A 1 'FILE: ' $GITHUB_STEP_SUMMARY | 
-        awk '
-          /FILE: / {
-            file = $2
-            next
-          }
-          /\[✖\]/ {
-            print file ": " $0
-          }
-        ' | tee >(sed -e 's/^/  /' >> $GITHUB_STEP_SUMMARY)
-        
-        if grep -q '\[✖\]' $GITHUB_STEP_SUMMARY; then
-          echo "## ❌ Broken Links Detected" | tee -a $GITHUB_STEP_SUMMARY
+        if grep -q '\[✖\]' "$GITHUB_STEP_SUMMARY"; then
+          echo "## ❌ Broken Links Detected"
+          
+          awk '
+            BEGIN { file = "unknown" }
+            /^FILE: / {
+              file = $2
+              next
+            }
+            /\[✖\]/ {
+              print file ": " $0
+            }
+          ' "$GITHUB_STEP_SUMMARY" | while IFS= read -r line; do
+            echo "  $line"
+          done
+          
+          echo "Total broken links: $(grep -c '\[✖\]' "$GITHUB_STEP_SUMMARY")"
           exit 1
         else
-          echo "## ✅ All Links Validated Successfully" | tee -a $GITHUB_STEP_SUMMARY
+          echo "## ✅ All Links Validated Successfully"
+          exit 0
         fi
-        
       env:
         GITHUB_STEP_SUMMARY: ${{ github.step_summary }}

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -25,3 +25,20 @@ runs:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
+    
+    - name: Extract and print broken links
+      if: always()
+      shell: bash
+      run: |
+        OUTPUT="${{ steps.markdown-link-check.outputs.output }}"
+        echo "OUTPUT: $OUTPUT"
+        
+        if [ -z "$OUTPUT" ]; then
+          OUTPUT=$(grep -E '^::|^\s*\[' "$GITHUB_STEP_SUMMARY" || true)
+        fi
+        
+        echo "### Broken Links Found" >> $GITHUB_STEP_SUMMARY
+        echo "$OUTPUT" | grep -E '\[✖\]|ERROR:' >> $GITHUB_STEP_SUMMARY || echo "No broken links found"
+        
+        echo "Extracted broken links:"
+        echo "$OUTPUT" | grep -E '\[✖\]|ERROR:' || echo "No broken links found"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -29,6 +29,7 @@ runs:
 
     - name: Show error links summary
       if: always()
+      shell: bash
       run: |
         echo -e "\n\n### Error Links Summary ###"        
         grep -B 1 '"status": [^2]' link-results.json | \

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -32,28 +32,41 @@ runs:
       run: |
         output=$(echo "$MLC_OUTPUT")
         
-        if grep -q '\[✖\]' <<< "$output"; then
+        if echo "$output" | grep -q '\[✖\]'; then
           echo "##[error]Found broken links:"
           echo "========================================"
           
           current_file=""
           error_count=0
+          in_error_block=false
+          error_description=""
           
           while IFS= read -r line; do
             if [[ "$line" =~ ^FILE:\ (.+) ]]; then
               current_file="${BASH_REMATCH[1]}"
+              in_error_block=false
             elif [[ "$line" =~ \[✖\]\ (.+)\ →\ Status:\ ([0-9]+) ]]; then
               ((error_count++))
               link="${BASH_REMATCH[1]}"
               status="${BASH_REMATCH[2]}"
+              in_error_block=true
+              
+              error_description=$(echo "$line" | sed -E 's/.*Status: [0-9]+ //')
               
               echo "📄 File: $current_file"
               echo "🔗 Link: $link"
               echo "🛑 Status: $status"
-              echo "----------------------------------------"
+              echo "📝 Error description:"
+            elif $in_error_block; then
+              if [[ "$line" =~ ^\ *$ ]] || [[ "$line" =~ ^[^\ ] ]]; then
+                in_error_block=false
+              else
+                echo "   $line"
+              fi
             fi
           done <<< "$output"
           
+          echo "----------------------------------------"
           echo "========================================"
           echo "##[error]Found $error_count broken links"
           

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -32,40 +32,33 @@ runs:
       run: |
         has_errors=0
         current_file=""
-        broken_links=()
-        
-        function print_broken_links() {
-          if [ ${#broken_links[@]} -gt 0 ]; then
-            has_errors=1
-            echo "File: $current_file"
-            for link_info in "${broken_links[@]}"; do
-              echo "  Broken link: $link_info"
-            done
-            echo ""
-          fi
-          broken_links=()
-        }
+        declare -A broken_links_map
         
         while IFS= read -r line; do
-          if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
-            if [ -n "$current_file" ]; then
-              print_broken_links
+            if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
+                current_file="${BASH_REMATCH[1]}"
+                broken_links_map[$current_file]=""
+            
+            elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
+                url="${BASH_REMATCH[1]}"
+                status="${BASH_REMATCH[2]}"
+                if [ -n "$current_file" ]; then
+                    broken_links_map[$current_file]+="  $url (Status: $status)"$'\n'
+                    has_errors=1
+                fi
             fi
-            current_file="${BASH_REMATCH[1]}"
-          
-          elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
-            url="${BASH_REMATCH[1]}"
-            status="${BASH_REMATCH[2]}"
-            broken_links+=("$url (Status: $status)")
-          fi
         done <<< "$MLC_OUTPUT"
         
-        if [ -n "$current_file" ]; then
-          print_broken_links
-        fi
-        
         if [ $has_errors -eq 0 ]; then
-          echo "✅ All links are valid"
-        else
-          echo "❌ Found broken links in the above files"
+            echo "=========== All links are valid ==========="
+        else            
+            echo "=========== Found errors: ==========="
+            
+            for file in "${!broken_links_map[@]}"; do
+                links="${broken_links_map[$file]}"
+                if [ -n "$links" ]; then
+                    echo "File: $file"
+                    echo "$links"
+                fi
+            done
         fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,7 +30,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        echo "${{ steps.markdown-link-check.outputs.result }}" > markdown-link-check.log
+        echo "${{ steps.markdown-link-check.outputs.stdout }}" > markdown-link-check.log
         echo -e "\n\n### 🔴 Broken Links Summary ###"
         grep -A 2 "ERROR:" markdown-link-check.log | awk '
           /FILE:/ {

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -27,6 +27,7 @@ runs:
         base-branch: 'gh-pages'
 
     - name: Capture logs via tee
+      if: always()
       shell: bash
       run: |
         # 运行原始action但通过tee捕获输出

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -26,23 +26,25 @@ runs:
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
 
-    - name: Capture and debug action logs
-      if: always()
+    - name: Capture logs via tee
       shell: bash
       run: |
-        LOG_CONTENT=$(curl -s -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ github.token }}" \
-          "${{ github.server_url }}/repos/${{ github.repository }}/actions/jobs/${{ github.job }}/logs" \
-          | awk '/^##\[group\]Run gaurav-nelson\/github-action-markdown-link-check/{flag=1;next}/##\[endgroup\]/{flag=0}flag')
+        # 运行原始action但通过tee捕获输出
+        echo "::group::Markdown Link Check"
+        npx markdown-link-check@https://github.com/gaurav-nelson/github-action-markdown-link-check \
+          --max-depth=${{ inputs.max-depth }} \
+          --verbose=${{ inputs.use-verbose-mode }} \
+          --base-branch=${{ inputs.base-branch }} \
+          . 2>&1 | tee mlc.log
+        echo "::endgroup::"
         
-        echo "### START OF CAPTURED LOG ###"
-        echo "$LOG_CONTENT"
-        echo "### END OF CAPTURED LOG ###"
-        
-        LOG_LENGTH=${#LOG_CONTENT}
-        echo "Captured log length: $LOG_LENGTH characters"
-        
+        # 保存日志
+        LOG_CONTENT=$(cat mlc.log)
         echo "LINK_CHECK_LOG<<EOF" >> $GITHUB_ENV
         echo "$LOG_CONTENT" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
         
+        # 调试输出
+        echo "### CAPTURED LOG (first 500 chars) ###"
+        echo "${LOG_CONTENT:0:500}"
+        echo "### END LOG PREVIEW ###"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -31,10 +31,16 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        echo "GITHUB_STEP_SUMMARY path: $GITHUB_STEP_SUMMARY"
-        echo "--- START OF STEP SUMMARY CONTENT ---"
-        cat "$GITHUB_STEP_SUMMARY"
-        echo "--- END OF STEP SUMMARY CONTENT ---"
+        LOG_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs"
+        JOB_ID=$(curl -s -H "Authorization: Bearer ${{ github.token }}" "$LOG_URL" | jq -r '.jobs[] | select(.name == "${{ github.job }}") | .id')
+        LOG_URL="https://api.github.com/repos/${{ github.repository }}/actions/jobs/$JOB_ID/logs"
+        
+        curl -s -H "Authorization: Bearer ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$LOG_URL" > full_log.txt
+        
+        sed -n '/> Run gaurav-nelson\/github-action-markdown-link-check@v1/,/^##\[endgroup\]/p' full_log.txt > mlc_output.log
+
+        cat mlc_output.log
+
         if grep -q '\[✖\]' "$GITHUB_STEP_SUMMARY"; then
           echo "## ❌ Broken Links Detected"
           

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,44 +30,38 @@ runs:
       shell: bash
       if: always()
       run: |
-        # Initialize variables
         has_errors=0
         current_file=""
-        file_summaries=()
+        files=()
+        summaries=()
         in_summary_section=0
         
         # Process output line by line
         while IFS= read -r line; do
             # Detect file header lines
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
-                # Save previous file summary
-                if [ -n "$current_file" ] && [ $in_summary_section -eq 1 ]; then
-                    file_summaries+=("$current_file")
-                    in_summary_section=0
-                fi
-                
                 current_file="${BASH_REMATCH[1]}"
+                in_summary_section=0
             
             # Detect start of summary section (after "n links checked.")
             elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]]; then
-                in_summary_section=1
-                # Start new summary for this file
-                file_summaries+=("$current_file")
-                file_summaries+=("$line")
+                if [ -n "$current_file" ]; then
+                    in_summary_section=1
+                    # Start new summary for this file
+                    files+=("$current_file")
+                    summaries+=("$line")
+                fi
             
             # Collect summary content
-            elif [ $in_summary_section -eq 1 ]; then
+            elif [ $in_summary_section -eq 1 ] && [ -n "$current_file" ]; then
                 # Add to current summary
-                file_summaries+=("$line")
+                last_index=$((${#summaries[@]} - 1))
+                summaries[$last_index]+=$'\n'"$line"
                 
                 # Check if this line indicates an error
                 if [[ "$line" =~ ERROR: ]] || [[ "$line" =~ \[✖\] ]]; then
                     has_errors=1
                 fi
-            
-            # Reset summary section flag when we hit a blank line or new file
-            elif [[ -z "$line" ]] || [[ "$line" =~ ^FILE: ]]; then
-                in_summary_section=0
             fi
         done <<< "$MLC_OUTPUT"
         
@@ -82,23 +76,17 @@ runs:
         echo "===== DETAILS ====="
         
         # Output error details
-        current_filename=""
-        for line in "${file_summaries[@]}"; do
-            # If line is a filename
-            if [[ "$line" =~ ^FILE: ]]; then
-                current_filename="${line#FILE: }"
-                continue
-            fi
+        for i in "${!files[@]}"; do
+            filename="${files[$i]}"
+            summary="${summaries[$i]}"
             
             # Only show summaries that contain errors
-            if [[ "$line" =~ ERROR: ]] || [[ "$line" =~ \[✖\] ]]; then
-                # Print filename if it's the start of a summary block
-                if [ -n "$current_filename" ]; then
-                    echo "File: $current_filename"
-                    current_filename=""
-                fi
-                
-                # Print the line with proper indentation
-                echo "  $line"
+            if [[ "$summary" =~ ERROR: ]] || [[ "$summary" =~ \[✖\] ]]; then
+                echo "File: $filename"
+                # Preserve newlines in summary
+                while IFS= read -r s_line; do
+                    echo "  $s_line"
+                done <<< "$summary"
+                echo  # Add empty line between files
             fi
         done

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,47 +30,5 @@ runs:
       shell: bash
       if: always()
       run: |
-        output=$(echo "$MLC_OUTPUT")
-        
-        if echo "$output" | grep -q '\[✖\]'; then
-          echo "##[error]Found broken links:"
-          echo "========================================"
-          
-          current_file=""
-          error_count=0
-          in_error_block=false
-          error_description=""
-          
-          while IFS= read -r line; do
-            if [[ "$line" =~ ^FILE:\ (.+) ]]; then
-              current_file="${BASH_REMATCH[1]}"
-              in_error_block=false
-            elif [[ "$line" =~ \[✖\]\ (.+)\ →\ Status:\ ([0-9]+) ]]; then
-              ((error_count++))
-              link="${BASH_REMATCH[1]}"
-              status="${BASH_REMATCH[2]}"
-              in_error_block=true
-              
-              error_description=$(echo "$line" | sed -E 's/.*Status: [0-9]+ //')
-              
-              echo "📄 File: $current_file"
-              echo "🔗 Link: $link"
-              echo "🛑 Status: $status"
-              echo "📝 Error description:"
-            elif $in_error_block; then
-              if [[ "$line" =~ ^\ *$ ]] || [[ "$line" =~ ^[^\ ] ]]; then
-                in_error_block=false
-              else
-                echo "   $line"
-              fi
-            fi
-          done <<< "$output"
-          
-          echo "----------------------------------------"
-          echo "========================================"
-          echo "##[error]Found $error_count broken links"
-          
-          exit 1
-        else
-          echo "✅ All links are valid"
-        fi
+        output="$MLC_OUTPUT"
+        echo "$output"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         echo "${{ steps.markdown-link-check.outputs.result }}" > markdown-link-check.log
         echo -e "\n\n### 🔴 Broken Links Summary ###"
-        grep -A 2 "ERROR:" link-check.log | awk '
+        grep -A 2 "ERROR:" markdown-link-check.log | awk '
           /FILE:/ {
             filename = substr($0, 7)
             next
@@ -50,7 +50,7 @@ runs:
           }
         ' | sort -u
         
-        count=$(grep -c "\[✖\]" link-check.log)
+        count=$(grep -c "\[✖\]" markdown-link-check.log)
         echo "### 🔍 Total broken links: ${count:-0}"
         
-        rm -f link-check.log
+        rm -f markdown-link-check.log

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -31,6 +31,10 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
+        echo "GITHUB_STEP_SUMMARY path: $GITHUB_STEP_SUMMARY"
+        echo "--- START OF STEP SUMMARY CONTENT ---"
+        cat "$GITHUB_STEP_SUMMARY"
+        echo "--- END OF STEP SUMMARY CONTENT ---"
         if grep -q '\[✖\]' "$GITHUB_STEP_SUMMARY"; then
           echo "## ❌ Broken Links Detected"
           

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -26,42 +26,22 @@ runs:
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
 
-    - name: Extract broken links
-      id: error-extractor
-      if: ${{ always() }}
+    - name: Capture and debug action logs
       shell: bash
       run: |
-        LOG_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs"
-        JOB_ID=$(curl -s -H "Authorization: Bearer ${{ github.token }}" "$LOG_URL" | jq -r '.jobs[] | select(.name == "${{ github.job }}") | .id')
-        LOG_URL="https://api.github.com/repos/${{ github.repository }}/actions/jobs/$JOB_ID/logs"
+        LOG_CONTENT=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ github.token }}" \
+          "${{ github.server_url }}/repos/${{ github.repository }}/actions/jobs/${{ github.job }}/logs" \
+          | awk '/^##\[group\]Run gaurav-nelson\/github-action-markdown-link-check/{flag=1;next}/##\[endgroup\]/{flag=0}flag')
         
-        curl -s -H "Authorization: Bearer ${{ github.token }}" -H "Accept: application/vnd.github.v3+json" "$LOG_URL" > full_log.txt
+        echo "### START OF CAPTURED LOG ###"
+        echo "$LOG_CONTENT"
+        echo "### END OF CAPTURED LOG ###"
         
-        sed -n '/> Run gaurav-nelson\/github-action-markdown-link-check@v1/,/^##\[endgroup\]/p' full_log.txt > mlc_output.log
-
-        cat mlc_output.log
-
-        if grep -q '\[✖\]' "$GITHUB_STEP_SUMMARY"; then
-          echo "## ❌ Broken Links Detected"
-          
-          awk '
-            BEGIN { file = "unknown" }
-            /^FILE: / {
-              file = $2
-              next
-            }
-            /\[✖\]/ {
-              print file ": " $0
-            }
-          ' "$GITHUB_STEP_SUMMARY" | while IFS= read -r line; do
-            echo "  $line"
-          done
-          
-          echo "Total broken links: $(grep -c '\[✖\]' "$GITHUB_STEP_SUMMARY")"
-          exit 1
-        else
-          echo "## ✅ All Links Validated Successfully"
-          exit 0
-        fi
-      env:
-        GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        LOG_LENGTH=${#LOG_CONTENT}
+        echo "Captured log length: $LOG_LENGTH characters"
+        
+        echo "LINK_CHECK_LOG<<EOF" >> $GITHUB_ENV
+        echo "$LOG_CONTENT" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+        

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -19,38 +19,38 @@ runs:
   using: "composite"
   steps:
     - name: Run markdown link check
+      id: markdown-link-check
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-        output-format: json
-        output-file: link-results.json
 
     - name: Show error links summary
       if: always()
       shell: bash
       run: |
-        echo -e "\n\n### Error Links Summary ###"        
-        grep -B 1 '"status": [^2]' link-results.json | \
-        awk '
-          /"link":/ {
-            gsub(/^[ \t]+"link": "/, "", $0);
-            gsub(/",?$/, "", $0);
-            link = $0
+        echo "${{ steps.markdown-link-check.outputs.result }}" > markdown-link-check.log
+        echo -e "\n\n### 🔴 Broken Links Summary ###"
+        grep -A 2 "ERROR:" link-check.log | awk '
+          /FILE:/ {
+            filename = substr($0, 7)
+            next
           }
-          /"status":/ {
+          /\[✖\]/ {
+            link = $2
+            next
+          }
+          /STATUS:/ {
             status = $2
-            sub(/,/, "", status);
-          }
-          /"filename":/ {
-            gsub(/^[ \t]+"filename": "/, "", $0);
-            gsub(/",?$/, "", $0);
-            if (link != "" && status != "" && $0 != "") {
-              printf "[%s] %-60s => %s\n", status, link, $0
-              link = ""; status = ""
+            if (link != "" && status != "" && filename != "") {
+              printf "[%s] %-50s => %s\n", status, link, filename
             }
+            link = ""; status = ""; filename = ""
           }
         ' | sort -u
         
-        echo "### Total broken links: $(grep -c '"status": [^2]' link-results.json)"
+        count=$(grep -c "\[✖\]" link-check.log)
+        echo "### 🔍 Total broken links: ${count:-0}"
+        
+        rm -f link-check.log

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -32,20 +32,13 @@ runs:
       run: |
         has_errors=0
         current_file=""
-        declare -A broken_links_map
-        declare -A current_file_links
+        files=()
+        all_links=()
         
         while IFS= read -r line; do
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
-                if [ -n "$current_file" ]; then
-                    if [ ${#current_file_links[@]} -gt 0 ]; then
-                        broken_links_map[$current_file]="${current_file_links[*]}"
-                    fi
-                fi
-                
                 current_file="${BASH_REMATCH[1]}"
-                unset current_file_links
-                declare -A current_file_links
+                files+=("$current_file")
             
             elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
                 url="${BASH_REMATCH[1]}"
@@ -53,26 +46,41 @@ runs:
                 link_str="$url (Status: $status)"
                 
                 if [ -n "$current_file" ]; then
-                    current_file_links["$link_str"]=1
+                    all_links+=("${current_file}|${link_str}")
                     has_errors=1
                 fi
             fi
         done <<< "$MLC_OUTPUT"
         
-        if [ -n "$current_file" ] && [ ${#current_file_links[@]} -gt 0 ]; then
-            broken_links_map[$current_file]="${!current_file_links[*]}"
+        # 输出结论
+        if [ $has_errors -eq 0 ]; then
+            echo "All links are valid"
+            exit 0
         fi
         
-        if [ $has_errors -eq 0 ]; then
-            echo "=========== All links are valid ==========="
-        else
-            echo "=========== Found broken links ==========="
-            
-            for file in "${!broken_links_map[@]}"; do
-                IFS=' ' read -ra links <<< "${broken_links_map[$file]}"
-                
-                echo "File: $file"
-                printf "  %s\n" "${links[@]}" | sort
-                echo
+        echo "Found broken links"
+        echo
+        echo "===== DETAILS ====="
+        
+        unique_files=($(printf "%s\n" "${files[@]}" | sort -u))
+        
+        unique_links=($(printf "%s\n" "${all_links[@]}" | sort -u))
+        
+        for file in "${unique_files[@]}"; do
+            file_links=()
+            for link in "${unique_links[@]}"; do
+                if [[ "$link" == "${file}|"* ]]; then
+                    link_only="${link#*|}"
+                    file_links+=("$link_only")
+                fi
             done
-        fi
+            
+            if [ ${#file_links[@]} -gt 0 ]; then
+                echo "File: $file"
+                
+                printf "  %s\n" "${file_links[@]}" | sort -u
+                
+                echo "  → Found ${#file_links[@]} broken link(s)"
+                echo
+            fi
+        done

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -63,18 +63,15 @@ runs:
                     has_errors=1
                 fi
             fi
-        done <<< "$MLC_OUTPUT"
+        done <<< "$MLC_OUTPUT" # This is the output of the markdown link check action
         
         # Output final conclusion
         if [ $has_errors -eq 0 ]; then
-            echo "✅ All links are valid"
+            echo "=========== All links are valid ==========="
             exit 0
         fi
         
-        echo "❌ Found broken links"
-        echo
-        echo "===== DETAILS ====="
-        
+        echo "=========== Found broken links ==========="        
         # Output error details
         for i in "${!files[@]}"; do
             filename="${files[$i]}"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -35,47 +35,41 @@ runs:
         current_file=""
         file_summaries=()
         in_summary_section=0
-        current_summary=""
         
         # Process output line by line
         while IFS= read -r line; do
             # Detect file header lines
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
                 # Save previous file summary
-                if [ -n "$current_file" ] && [ -n "$current_summary" ]; then
-                    file_summaries+=("$current_file|$current_summary")
-                    current_summary=""
+                if [ -n "$current_file" ] && [ $in_summary_section -eq 1 ]; then
+                    file_summaries+=("$current_file")
+                    in_summary_section=0
                 fi
                 
                 current_file="${BASH_REMATCH[1]}"
-                in_summary_section=0
             
             # Detect start of summary section (after "n links checked.")
             elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]]; then
                 in_summary_section=1
-                current_summary="$line"
+                # Start new summary for this file
+                file_summaries+=("$current_file")
+                file_summaries+=("$line")
             
             # Collect summary content
             elif [ $in_summary_section -eq 1 ]; then
-                # Skip empty lines at the start of summary
-                if [[ -z "$line" && -z "$current_summary" ]]; then
-                    continue
-                fi
-                
                 # Add to current summary
-                current_summary+="\n$line"
+                file_summaries+=("$line")
                 
                 # Check if this line indicates an error
                 if [[ "$line" =~ ERROR: ]] || [[ "$line" =~ \[✖\] ]]; then
                     has_errors=1
                 fi
+            
+            # Reset summary section flag when we hit a blank line or new file
+            elif [[ -z "$line" ]] || [[ "$line" =~ ^FILE: ]]; then
+                in_summary_section=0
             fi
         done <<< "$MLC_OUTPUT"
-        
-        # Save last file summary
-        if [ -n "$current_file" ] && [ -n "$current_summary" ]; then
-            file_summaries+=("$current_file|$current_summary")
-        fi
         
         # Output final conclusion
         if [ $has_errors -eq 0 ]; then
@@ -88,17 +82,23 @@ runs:
         echo "===== DETAILS ====="
         
         # Output error details
-        for entry in "${file_summaries[@]}"; do
-            # Split into filename and summary
-            IFS='|' read -r filename summary <<< "$entry"
+        current_filename=""
+        for line in "${file_summaries[@]}"; do
+            # If line is a filename
+            if [[ "$line" =~ ^FILE: ]]; then
+                current_filename="${line#FILE: }"
+                continue
+            fi
             
             # Only show summaries that contain errors
-            if [[ "$summary" =~ ERROR: ]] || [[ "$summary" =~ \[✖\] ]]; then
-                echo "File: $filename"
-                # Preserve newlines in summary
-                printf "%s\n" "$summary" | while IFS= read -r s_line; do
-                    echo "  $s_line"
-                done
-                echo
+            if [[ "$line" =~ ERROR: ]] || [[ "$line" =~ \[✖\] ]]; then
+                # Print filename if it's the start of a summary block
+                if [ -n "$current_filename" ]; then
+                    echo "File: $current_filename"
+                    current_filename=""
+                fi
+                
+                # Print the line with proper indentation
+                echo "  $line"
             fi
         done

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -34,7 +34,7 @@ runs:
         current_file=""
         files=()
         summaries=()
-        in_summary_section=0 # Flag to indicate if we are in the summary section
+        in_summary_section=0
         
         # Process output line by line
         while IFS= read -r line; do
@@ -49,6 +49,7 @@ runs:
                     in_summary_section=1
                     # Start new summary for this file
                     files+=("$current_file")
+                    summaries+=("Details:")
                 fi
             
             # Collect summary content

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -27,6 +27,7 @@ runs:
         base-branch: 'gh-pages'
 
     - name: Capture and debug action logs
+      if: always()
       shell: bash
       run: |
         LOG_CONTENT=$(curl -s -H "Accept: application/vnd.github.v3+json" \

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,44 +30,42 @@ runs:
       shell: bash
       if: always()
       run: |
-        {
-          has_error=0
-          current_file=""
+        has_errors=0
+        current_file=""
+        broken_links=()
+        
+        function print_broken_links() {
+          if [ ${#broken_links[@]} -gt 0 ]; then
+            has_errors=1
+            echo "File: $current_file"
+            for link_info in "${broken_links[@]}"; do
+              echo "  Broken link: $link_info"
+            done
+            echo ""
+          fi
           broken_links=()
+        }
+        
+        while IFS= read -r line; do
+          if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
+            if [ -n "$current_file" ]; then
+              print_broken_links
+            fi
+            current_file="${BASH_REMATCH[1]}"
           
-          function output_broken_links() {
-              if [ ${#broken_links[@]} -gt 0 ]; then
-                  has_error=1
-                  echo "File: $current_file"
-                  for link_info in "${broken_links[@]}"; do
-                      echo "  Broken link: $link_info"
-                  done
-                  echo ""
-              fi
-          }
-          
-          while IFS= read -r line; do
-              if [[ $line =~ ^[[:space:]]*FILE:[[:space:]]*(.+) ]]; then
-                  filename="${BASH_REMATCH[1]}"
-                  if [ -n "$current_file" ]; then
-                      output_broken_links
-                  fi
-                  current_file="$filename"
-                  broken_links=()
-              elif [[ $line =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
-                  url="${BASH_REMATCH[1]}"
-                  status="${BASH_REMATCH[2]}"
-                  broken_links+=("$url (Status: $status)")
-              fi
-          done <<< "$MLC_OUTPUT"
-          
-          if [ -n "$current_file" ]; then
-              output_broken_links
+          elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
+            url="${BASH_REMATCH[1]}"
+            status="${BASH_REMATCH[2]}"
+            broken_links+=("$url (Status: $status)")
           fi
-          
-          if [ $has_error -eq 0 ]; then
-              echo "All links are good!"
-          else
-              echo "Found broken links in the above files"
-          fi
-        } || true
+        done <<< "$MLC_OUTPUT"
+        
+        if [ -n "$current_file" ]; then
+          print_broken_links
+        fi
+        
+        if [ $has_errors -eq 0 ]; then
+          echo "✅ All links are valid"
+        else
+          echo "❌ Found broken links in the above files"
+        fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -25,35 +25,8 @@ runs:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-      shell: bash
+    
+    - name: Save output
       run: |
-        echo "::group::Markdown Link Check Output"
-        npx markdown-link-check@latest **/*.md --verbose 2>&1 | tee link-check.log
-        echo "::endgroup::"
-        echo "exit_code=$?" >> $GITHUB_OUTPUT
-
-    - name: Extract and print broken links
-      if: always()
+        echo "LINK_CHECK_OUTPUT=${{ steps.markdown-link-check.outputs.log }}" >> $GITHUB_ENV
       shell: bash
-      run: |
-        cat link-check.log
-        if [ "${{ steps.markdown-link-check.outputs.exit_code }}" != "0" ]; then
-          echo "Link check found errors. Parsing log..."
-          ERRORS=$(grep -E '\[✖\]|ERROR:' link-check.log || true)
-          
-          if [ -n "$ERRORS" ]; then
-            echo "### ❌ Broken Links Found" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$ERRORS" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "Found broken links:" 
-            echo "$ERRORS"
-            exit 1  # 使步骤失败
-          else
-            echo "Link check failed but no broken links detected." 
-            echo "Check full log for network issues."
-          fi
-        else
-          echo "### ✅ All links are valid" >> $GITHUB_STEP_SUMMARY
-          echo "No broken links found"
-        fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -34,7 +34,7 @@ runs:
         current_file=""
         files=()
         summaries=()
-        in_summary_section=0
+        in_summary_section=0 # Flag to indicate if we are in the summary section
         
         # Process output line by line
         while IFS= read -r line; do
@@ -49,7 +49,6 @@ runs:
                     in_summary_section=1
                     # Start new summary for this file
                     files+=("$current_file")
-                    summaries+=("$line")
                 fi
             
             # Collect summary content

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,27 +30,33 @@ runs:
       shell: bash
       if: always()
       run: |
-        if grep -q '\[✖\]' <<< "$MLC_OUTPUT"; then
-          echo "##Error found:"
+        output=$(cat "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "$MLC_OUTPUT")
+        
+        if grep -q '\[✖\]' <<< "$output"; then
+          echo "##[error]Found broken links:"
           echo "========================================"
           
           current_file=""
+          error_count=0
           
-          echo "$MLC_OUTPUT" | while IFS= read -r line; do
-            if [[ "$line" == FILE:* ]]; then
-              current_file="${line#FILE: }"
-            elif [[ "$line" == *'[✖]'* ]]; then
-              link=$(echo "$line" | grep -o 'https\?://[^ ]*' | head -1)
-              status=$(echo "$line" | grep -o 'Status: [0-9]\+' | cut -d' ' -f2)
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^FILE:\ (.+) ]]; then
+              current_file="${BASH_REMATCH[1]}"
+            elif [[ "$line" =~ \[✖\]\ (.+)\ →\ Status:\ ([0-9]+) ]]; then
+              ((error_count++))
+              link="${BASH_REMATCH[1]}"
+              status="${BASH_REMATCH[2]}"
               
               echo "📄 File: $current_file"
               echo "🔗 Link: $link"
               echo "🛑 Status: $status"
               echo "----------------------------------------"
             fi
-          done
+          done <<< "$output"
           
           echo "========================================"
+          echo "##[error]Found $error_count broken links"
+          
           exit 1
         else
           echo "✅ All links are valid"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,5 +30,44 @@ runs:
       shell: bash
       if: always()
       run: |
-        output="$MLC_OUTPUT"
-        echo "$output"
+        {
+          has_error=0
+          current_file=""
+          broken_links=()
+          
+          function output_broken_links() {
+              if [ ${#broken_links[@]} -gt 0 ]; then
+                  has_error=1
+                  echo "File: $current_file"
+                  for link_info in "${broken_links[@]}"; do
+                      echo "  Broken link: $link_info"
+                  done
+                  echo ""
+              fi
+          }
+          
+          while IFS= read -r line; do
+              if [[ $line =~ ^[[:space:]]*FILE:[[:space:]]*(.+) ]]; then
+                  filename="${BASH_REMATCH[1]}"
+                  if [ -n "$current_file" ]; then
+                      output_broken_links
+                  fi
+                  current_file="$filename"
+                  broken_links=()
+              elif [[ $line =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
+                  url="${BASH_REMATCH[1]}"
+                  status="${BASH_REMATCH[2]}"
+                  broken_links+=("$url (Status: $status)")
+              fi
+          done <<< "$MLC_OUTPUT"
+          
+          if [ -n "$current_file" ]; then
+              output_broken_links
+          fi
+          
+          if [ $has_error -eq 0 ]; then
+              echo "All links are good!"
+          else
+              echo "Found broken links in the above files"
+          fi
+        } || true

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -33,66 +33,48 @@ runs:
         # Initialize variables
         has_errors=0
         current_file=""
-        files=()
-        all_links=()
-        in_file_section=0
-        in_error_block=0
-        current_error=""
+        file_summaries=()
+        in_summary_section=0
+        current_summary=""
         
         # Process output line by line
         while IFS= read -r line; do
             # Detect file header lines
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
-                current_file="${BASH_REMATCH[1]}"
-                files+=("$current_file")
-                in_file_section=1
-                in_error_block=0
-            
-            # Skip summary lines that come after the actual link checks
-            elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]] ||
-                [[ "$line" =~ ^[[:space:]]*ERROR:[[:space:]]* ]] ||
-                [[ "$line" =~ ^[[:space:]]*\[✖\]\ [^[:space:]]+\ →\ Status:\ [0-9]+[[:space:]]*$ ]]; then
-                # Skip these summary lines
-                in_error_block=0
-                continue
-            
-            # Detect broken link lines - extract URL and status code
-            elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+)(.*)$ ]]; then
-                url="${BASH_REMATCH[1]}"
-                status="${BASH_REMATCH[2]}"
-                error_start="${BASH_REMATCH[3]}"
-                
-                # Only process if we're in a file section
-                if [ -n "$current_file" ] && [ $in_file_section -eq 1 ]; then
-                    # Start a new error block
-                    in_error_block=1
-                    current_error=$(echo "$error_start" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                # Save previous file summary
+                if [ -n "$current_file" ] && [ -n "$current_summary" ]; then
+                    file_summaries+=("$current_file|$current_summary")
+                    current_summary=""
                 fi
+                
+                current_file="${BASH_REMATCH[1]}"
+                in_summary_section=0
             
-            # Capture multi-line error messages
-            elif [ $in_error_block -eq 1 ] && [[ "$line" =~ ^[[:space:]]+ ]]; then
-                # Append to current error message
-                current_error+="\n$line"
+            # Detect start of summary section (after "n links checked.")
+            elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]]; then
+                in_summary_section=1
+                current_summary="$line"
             
-            # End of error block
-            elif [ $in_error_block -eq 1 ]; then
-                # Add to links array (format: file|url|status|error)
-                all_links+=("${current_file}|${url}|${status}|${current_error}")
-                has_errors=1
-                in_error_block=0
-                current_error=""
-            
-            # Reset file section flag when we hit a blank line
-            elif [[ -z "$line" ]]; then
-                in_file_section=0
-                in_error_block=0
+            # Collect summary content
+            elif [ $in_summary_section -eq 1 ]; then
+                # Skip empty lines at the start of summary
+                if [[ -z "$line" && -z "$current_summary" ]]; then
+                    continue
+                fi
+                
+                # Add to current summary
+                current_summary+="\n$line"
+                
+                # Check if this line indicates an error
+                if [[ "$line" =~ ERROR: ]] || [[ "$line" =~ \[✖\] ]]; then
+                    has_errors=1
+                fi
             fi
         done <<< "$MLC_OUTPUT"
         
-        # Capture any remaining error block at end of input
-        if [ $in_error_block -eq 1 ]; then
-            all_links+=("${current_file}|${url}|${status}|${current_error}")
-            has_errors=1
+        # Save last file summary
+        if [ -n "$current_file" ] && [ -n "$current_summary" ]; then
+            file_summaries+=("$current_file|$current_summary")
         fi
         
         # Output final conclusion
@@ -105,42 +87,18 @@ runs:
         echo
         echo "===== DETAILS ====="
         
-        # Remove duplicate files
-        unique_files=($(printf "%s\n" "${files[@]}" | sort -u))
-        
-        # Remove duplicate links
-        unique_links=($(printf "%s\n" "${all_links[@]}" | sort -u))
-        
         # Output error details
-        for file in "${unique_files[@]}"; do
-            file_links=()
-            for link in "${unique_links[@]}"; do
-                if [[ "$link" == "${file}|"* ]]; then
-                    # Extract link info (remove filename prefix)
-                    link_only="${link#*|}"
-                    file_links+=("$link_only")
-                fi
-            done
+        for entry in "${file_summaries[@]}"; do
+            # Split into filename and summary
+            IFS='|' read -r filename summary <<< "$entry"
             
-            # Output if file has broken links
-            if [ ${#file_links[@]} -gt 0 ]; then
-                echo "File: $file"
-                
-                # Output each broken link with details
-                for link_info in "${file_links[@]}"; do
-                    # Split link info into components
-                    IFS='|' read -r url status error_msg <<< "$link_info"
-                    
-                    # Format output with error message
-                    echo "  $url (Status: $status)"
-                    # Preserve newlines in error message
-                    printf "  %s\n" "$error_msg" | while IFS= read -r err_line; do
-                        echo "    $err_line"
-                    done
+            # Only show summaries that contain errors
+            if [[ "$summary" =~ ERROR: ]] || [[ "$summary" =~ \[✖\] ]]; then
+                echo "File: $filename"
+                # Preserve newlines in summary
+                printf "%s\n" "$summary" | while IFS= read -r s_line; do
+                    echo "  $s_line"
                 done
-                
-                # Add link count
-                echo "  → Found ${#file_links[@]} broken link(s)"
                 echo
             fi
         done

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -26,37 +26,26 @@ runs:
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
 
-    - name: Show error links summary
-      if: always()
+    - name: Extract broken links
+      id: error-extractor
       shell: bash
       run: |
-        OUTPUT=$(grep -A 3 "ERROR:" "$GITHUB_STEP_SUMMARY" || true)
-    
-        if [ -z "$OUTPUT" ]; then
-          echo "✅ All links are working"
-          exit 0
-        fi
+        LOG=$(grep -A 1 -E 'FILE: |\[✖\]' "$GITHUB_STEP_SUMMARY" | grep -v '^--$')
         
-        echo -e "\n\n### 🔴 Broken Links Summary ###"
-        echo "$OUTPUT" | awk '
-          BEGIN {
-            link = ""; status = ""; file = ""
+        echo "$LOG" | awk '
+          /FILE: / {
+            file = $2
+            next
           }
           /\[✖\]/ {
-            gsub("\\[✖\\] ", "", $0)
-            link = $0
+            print file ": " $0
           }
-          /STATUS:/ {
-            status = $2
-          }
-          /FILE:/ {
-            file = substr($0, 7)
-            if (link != "" && status != "" && file != "") {
-              printf "[%s] %-50s => %s\n", status, link, file
-              link = ""; status = ""; file = ""
-            }
-          }
-        ' | sort -u
+        ' > broken_links.log
         
-        count=$(echo "$OUTPUT" | grep -c "\[✖\]")
-        echo "### 🔍 Total broken links: $count"
+        echo "## 📛 Broken Links Report" >> $GITHUB_STEP_SUMMARY
+        echo "```" >> $GITHUB_STEP_SUMMARY
+        cat broken_links.log >> $GITHUB_STEP_SUMMARY
+        echo "```" >> $GITHUB_STEP_SUMMARY
+        
+      env:
+        GITHUB_STEP_SUMMARY: ${{ github.step_summary }}

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -35,6 +35,7 @@ runs:
         current_file=""
         files=()
         all_links=()
+        in_file_section=0
         
         # Process output line by line
         while IFS= read -r line; do
@@ -42,6 +43,14 @@ runs:
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
                 current_file="${BASH_REMATCH[1]}"
                 files+=("$current_file")
+                in_file_section=1
+            
+            # Skip summary lines that come after the actual link checks
+            elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]] ||
+                [[ "$line" =~ ^[[:space:]]*ERROR:[[:space:]]* ]] ||
+                [[ "$line" =~ ^[[:space:]]*\[✖\]\ [^[:space:]]+\ →\ Status:\ [0-9]+[[:space:]]*$ ]]; then
+                # Skip these summary lines
+                continue
             
             # Detect broken link lines - extract URL, status code, and error message
             elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+)(.*)$ ]]; then
@@ -49,14 +58,19 @@ runs:
                 status="${BASH_REMATCH[2]}"
                 error_msg="${BASH_REMATCH[3]}"
                 
-                # Clean up error message (trim leading/trailing whitespace)
-                error_msg=$(echo "$error_msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                
-                # Add to links array (format: file|url|status|error)
-                if [ -n "$current_file" ]; then
+                # Only process if we're in a file section
+                if [ -n "$current_file" ] && [ $in_file_section -eq 1 ]; then
+                    # Clean up error message (trim leading/trailing whitespace)
+                    error_msg=$(echo "$error_msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                    
+                    # Add to links array (format: file|url|status|error)
                     all_links+=("${current_file}|${url}|${status}|${error_msg}")
                     has_errors=1
                 fi
+            
+            # Reset file section flag when we hit a blank line
+            elif [[ -z "$line" ]]; then
+                in_file_section=0
             fi
         done <<< "$MLC_OUTPUT"
         

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,4 +30,6 @@ runs:
       shell: bash
       if: always()
       run: |
-        echo "LINK_CHECK_OUTPUT=${{ steps.markdown-link-check.outputs.log }}" >> $GITHUB_ENV
+        echo "========= test start =========="
+        echo "$MLC_OUTPUT"
+        echo "========= test end =========="

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -33,32 +33,46 @@ runs:
         has_errors=0
         current_file=""
         declare -A broken_links_map
+        declare -A current_file_links
         
         while IFS= read -r line; do
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
+                if [ -n "$current_file" ]; then
+                    if [ ${#current_file_links[@]} -gt 0 ]; then
+                        broken_links_map[$current_file]="${current_file_links[*]}"
+                    fi
+                fi
+                
                 current_file="${BASH_REMATCH[1]}"
-                broken_links_map[$current_file]=""
+                unset current_file_links
+                declare -A current_file_links
             
             elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
                 url="${BASH_REMATCH[1]}"
                 status="${BASH_REMATCH[2]}"
+                link_str="$url (Status: $status)"
+                
                 if [ -n "$current_file" ]; then
-                    broken_links_map[$current_file]+="  $url (Status: $status)"$'\n'
+                    current_file_links["$link_str"]=1
                     has_errors=1
                 fi
             fi
         done <<< "$MLC_OUTPUT"
         
+        if [ -n "$current_file" ] && [ ${#current_file_links[@]} -gt 0 ]; then
+            broken_links_map[$current_file]="${!current_file_links[*]}"
+        fi
+        
         if [ $has_errors -eq 0 ]; then
             echo "=========== All links are valid ==========="
-        else            
-            echo "=========== Found errors: ==========="
+        else
+            echo "=========== Found broken links ==========="
             
             for file in "${!broken_links_map[@]}"; do
-                links="${broken_links_map[$file]}"
-                if [ -n "$links" ]; then
-                    echo "File: $file"
-                    echo "$links"
-                fi
+                IFS=' ' read -ra links <<< "${broken_links_map[$file]}"
+                
+                echo "File: $file"
+                printf "  %s\n" "${links[@]}" | sort
+                echo
             done
         fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -25,20 +25,35 @@ runs:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-    
+        shell: bash
+      run: |
+        echo "::group::Markdown Link Check Output"
+        npx markdown-link-check@latest **/*.md --verbose 2>&1 | tee link-check.log
+        echo "::endgroup::"
+        echo "exit_code=$?" >> $GITHUB_OUTPUT
+
     - name: Extract and print broken links
       if: always()
       shell: bash
       run: |
-        OUTPUT="${{ steps.markdown-link-check.outputs.output }}"
-        echo "OUTPUT: $OUTPUT"
-        
-        if [ -z "$OUTPUT" ]; then
-          OUTPUT=$(grep -E '^::|^\s*\[' "$GITHUB_STEP_SUMMARY" || true)
+        cat link-check.log
+        if [ "${{ steps.markdown-link-check.outputs.exit_code }}" != "0" ]; then
+          echo "Link check found errors. Parsing log..."
+          ERRORS=$(grep -E '\[✖\]|ERROR:' link-check.log || true)
+          
+          if [ -n "$ERRORS" ]; then
+            echo "### ❌ Broken Links Found" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$ERRORS" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "Found broken links:" 
+            echo "$ERRORS"
+            exit 1  # 使步骤失败
+          else
+            echo "Link check failed but no broken links detected." 
+            echo "Check full log for network issues."
+          fi
+        else
+          echo "### ✅ All links are valid" >> $GITHUB_STEP_SUMMARY
+          echo "No broken links found"
         fi
-        
-        echo "### Broken Links Found" >> $GITHUB_STEP_SUMMARY
-        echo "$OUTPUT" | grep -E '\[✖\]|ERROR:' >> $GITHUB_STEP_SUMMARY || echo "No broken links found"
-        
-        echo "Extracted broken links:"
-        echo "$OUTPUT" | grep -E '\[✖\]|ERROR:' || echo "No broken links found"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -20,32 +20,8 @@ runs:
   steps:
     - name: Run markdown link check
       id: markdown-link-check
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@v1
       with:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-
-    - name: Capture logs via tee
-      if: always()
-      shell: bash
-      run: |
-        # 运行原始action但通过tee捕获输出
-        echo "::group::Markdown Link Check"
-        npx markdown-link-check@https://github.com/gaurav-nelson/github-action-markdown-link-check \
-          --max-depth=${{ inputs.max-depth }} \
-          --verbose=${{ inputs.use-verbose-mode }} \
-          --base-branch=${{ inputs.base-branch }} \
-          . 2>&1 | tee mlc.log
-        echo "::endgroup::"
-        
-        # 保存日志
-        LOG_CONTENT=$(cat mlc.log)
-        echo "LINK_CHECK_LOG<<EOF" >> $GITHUB_ENV
-        echo "$LOG_CONTENT" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
-        
-        # 调试输出
-        echo "### CAPTURED LOG (first 500 chars) ###"
-        echo "${LOG_CONTENT:0:500}"
-        echo "### END LOG PREVIEW ###"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,27 +30,33 @@ runs:
       if: always()
       shell: bash
       run: |
-        echo "${{ steps.markdown-link-check.outputs.stdout }}" > markdown-link-check.log
+        OUTPUT=$(grep -A 3 "ERROR:" "$GITHUB_STEP_SUMMARY" || true)
+    
+        if [ -z "$OUTPUT" ]; then
+          echo "✅ All links are working"
+          exit 0
+        fi
+        
         echo -e "\n\n### 🔴 Broken Links Summary ###"
-        grep -A 2 "ERROR:" markdown-link-check.log | awk '
-          /FILE:/ {
-            filename = substr($0, 7)
-            next
+        echo "$OUTPUT" | awk '
+          BEGIN {
+            link = ""; status = ""; file = ""
           }
           /\[✖\]/ {
-            link = $2
-            next
+            gsub("\\[✖\\] ", "", $0)
+            link = $0
           }
           /STATUS:/ {
             status = $2
-            if (link != "" && status != "" && filename != "") {
-              printf "[%s] %-50s => %s\n", status, link, filename
+          }
+          /FILE:/ {
+            file = substr($0, 7)
+            if (link != "" && status != "" && file != "") {
+              printf "[%s] %-50s => %s\n", status, link, file
+              link = ""; status = ""; file = ""
             }
-            link = ""; status = ""; filename = ""
           }
         ' | sort -u
         
-        count=$(grep -c "\[✖\]" markdown-link-check.log)
-        echo "### 🔍 Total broken links: ${count:-0}"
-        
-        rm -f markdown-link-check.log
+        count=$(echo "$OUTPUT" | grep -c "\[✖\]")
+        echo "### 🔍 Total broken links: $count"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,6 +30,7 @@ runs:
       shell: bash
       if: always()
       run: |
+        echo "Summarizing markdown link check results"
         set -e
         
         has_errors=0

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -25,7 +25,7 @@ runs:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-        shell: bash
+      shell: bash
       run: |
         echo "::group::Markdown Link Check Output"
         npx markdown-link-check@latest **/*.md --verbose 2>&1 | tee link-check.log

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,26 +30,28 @@ runs:
       shell: bash
       if: always()
       run: |
-        if grep -q 'ERROR:' <<< "$MLC_OUTPUT"; then
-          echo "Found broken links:"
-          echo "-------------------------------"
+        if grep -q '\[✖\]' <<< "$MLC_OUTPUT"; then
+          echo "##Error found:"
+          echo "========================================"
           
-          echo "$MLC_OUTPUT" | grep -E '(FILE:|ERROR:)' | while read -r line; do
-            if [[ $line == FILE:* ]]; then
+          current_file=""
+          
+          echo "$MLC_OUTPUT" | while IFS= read -r line; do
+            if [[ "$line" == FILE:* ]]; then
               current_file="${line#FILE: }"
-            elif [[ $line == *ERROR:* ]]; then
-              link=$(echo "$line" | sed -E 's/.*https?:\/\/[^ ]+//; s/ .*//')
-              status=$(echo "$line" | grep -oE 'status: [0-9]+' | cut -d' ' -f2)
+            elif [[ "$line" == *'[✖]'* ]]; then
+              link=$(echo "$line" | grep -o 'https\?://[^ ]*' | head -1)
+              status=$(echo "$line" | grep -o 'Status: [0-9]\+' | cut -d' ' -f2)
               
-              printf "%s\n%s\n%s\n\n" \
-                "$current_file" \
-                "$link" \
-                "Status: $status"
+              echo "📄 File: $current_file"
+              echo "🔗 Link: $link"
+              echo "🛑 Status: $status"
+              echo "----------------------------------------"
             fi
           done
           
-          echo "-------------------------------"
+          echo "========================================"
           exit 1
         else
-          echo "All links are valid"
+          echo "✅ All links are valid"
         fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       if: always()
       run: |
-        output=$(cat "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "$MLC_OUTPUT")
+        output=$(echo "$MLC_OUTPUT")
         
         if grep -q '\[✖\]' <<< "$output"; then
           echo "##[error]Found broken links:"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -26,10 +26,30 @@ runs:
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
     
-    - name: Save output
+    - name: Summarize results
       shell: bash
       if: always()
       run: |
-        echo "========= test start =========="
-        echo "$MLC_OUTPUT"
-        echo "========= test end =========="
+        if grep -q 'ERROR:' <<< "$MLC_OUTPUT"; then
+          echo "Found broken links:"
+          echo "-------------------------------"
+          
+          echo "$MLC_OUTPUT" | grep -E '(FILE:|ERROR:)' | while read -r line; do
+            if [[ $line == FILE:* ]]; then
+              current_file="${line#FILE: }"
+            elif [[ $line == *ERROR:* ]]; then
+              link=$(echo "$line" | sed -E 's/.*https?:\/\/[^ ]+//; s/ .*//')
+              status=$(echo "$line" | grep -oE 'status: [0-9]+' | cut -d' ' -f2)
+              
+              printf "%s\n%s\n%s\n\n" \
+                "$current_file" \
+                "$link" \
+                "Status: $status"
+            fi
+          done
+          
+          echo "-------------------------------"
+          exit 1
+        else
+          echo "All links are valid"
+        fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -36,6 +36,8 @@ runs:
         files=()
         all_links=()
         in_file_section=0
+        in_error_block=0
+        current_error=""
         
         # Process output line by line
         while IFS= read -r line; do
@@ -44,35 +46,54 @@ runs:
                 current_file="${BASH_REMATCH[1]}"
                 files+=("$current_file")
                 in_file_section=1
+                in_error_block=0
             
             # Skip summary lines that come after the actual link checks
             elif [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]*links[[:space:]]*checked\. ]] ||
                 [[ "$line" =~ ^[[:space:]]*ERROR:[[:space:]]* ]] ||
                 [[ "$line" =~ ^[[:space:]]*\[✖\]\ [^[:space:]]+\ →\ Status:\ [0-9]+[[:space:]]*$ ]]; then
                 # Skip these summary lines
+                in_error_block=0
                 continue
             
-            # Detect broken link lines - extract URL, status code, and error message
+            # Detect broken link lines - extract URL and status code
             elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+)(.*)$ ]]; then
                 url="${BASH_REMATCH[1]}"
                 status="${BASH_REMATCH[2]}"
-                error_msg="${BASH_REMATCH[3]}"
+                error_start="${BASH_REMATCH[3]}"
                 
                 # Only process if we're in a file section
                 if [ -n "$current_file" ] && [ $in_file_section -eq 1 ]; then
-                    # Clean up error message (trim leading/trailing whitespace)
-                    error_msg=$(echo "$error_msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                    
-                    # Add to links array (format: file|url|status|error)
-                    all_links+=("${current_file}|${url}|${status}|${error_msg}")
-                    has_errors=1
+                    # Start a new error block
+                    in_error_block=1
+                    current_error=$(echo "$error_start" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
                 fi
+            
+            # Capture multi-line error messages
+            elif [ $in_error_block -eq 1 ] && [[ "$line" =~ ^[[:space:]]+ ]]; then
+                # Append to current error message
+                current_error+="\n$line"
+            
+            # End of error block
+            elif [ $in_error_block -eq 1 ]; then
+                # Add to links array (format: file|url|status|error)
+                all_links+=("${current_file}|${url}|${status}|${current_error}")
+                has_errors=1
+                in_error_block=0
+                current_error=""
             
             # Reset file section flag when we hit a blank line
             elif [[ -z "$line" ]]; then
                 in_file_section=0
+                in_error_block=0
             fi
         done <<< "$MLC_OUTPUT"
+        
+        # Capture any remaining error block at end of input
+        if [ $in_error_block -eq 1 ]; then
+            all_links+=("${current_file}|${url}|${status}|${current_error}")
+            has_errors=1
+        fi
         
         # Output final conclusion
         if [ $has_errors -eq 0 ]; then
@@ -110,12 +131,12 @@ runs:
                     # Split link info into components
                     IFS='|' read -r url status error_msg <<< "$link_info"
                     
-                    # Format output with error message if present
-                    if [ -n "$error_msg" ]; then
-                        echo "  $url (Status: $status): $error_msg"
-                    else
-                        echo "  $url (Status: $status)"
-                    fi
+                    # Format output with error message
+                    echo "  $url (Status: $status)"
+                    # Preserve newlines in error message
+                    printf "  %s\n" "$error_msg" | while IFS= read -r err_line; do
+                        echo "    $err_line"
+                    done
                 done
                 
                 # Add link count

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,9 +30,8 @@ runs:
       id: error-extractor
       shell: bash
       run: |
-        LOG=$(grep -A 1 -E 'FILE: |\[✖\]' "$GITHUB_STEP_SUMMARY" | grep -v '^--$')
-        
-        echo "$LOG" | awk '
+        grep -A 1 'FILE: ' $GITHUB_STEP_SUMMARY | 
+        awk '
           /FILE: / {
             file = $2
             next
@@ -40,12 +39,14 @@ runs:
           /\[✖\]/ {
             print file ": " $0
           }
-        ' > broken_links.log
+        ' | tee >(sed -e 's/^/  /' >> $GITHUB_STEP_SUMMARY)
         
-        echo "## 📛 Broken Links Report" >> $GITHUB_STEP_SUMMARY
-        echo "```" >> $GITHUB_STEP_SUMMARY
-        cat broken_links.log >> $GITHUB_STEP_SUMMARY
-        echo "```" >> $GITHUB_STEP_SUMMARY
+        if grep -q '\[✖\]' $GITHUB_STEP_SUMMARY; then
+          echo "## ❌ Broken Links Detected" | tee -a $GITHUB_STEP_SUMMARY
+          exit 1
+        else
+          echo "## ✅ All Links Validated Successfully" | tee -a $GITHUB_STEP_SUMMARY
+        fi
         
       env:
         GITHUB_STEP_SUMMARY: ${{ github.step_summary }}

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -28,6 +28,7 @@ runs:
 
     - name: Extract broken links
       id: error-extractor
+      if: ${{ always() }}
       shell: bash
       run: |
         grep -A 1 'FILE: ' $GITHUB_STEP_SUMMARY | 

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -27,6 +27,7 @@ runs:
         base-branch: 'gh-pages'
     
     - name: Save output
+      shell: bash
+      if: always()
       run: |
         echo "LINK_CHECK_OUTPUT=${{ steps.markdown-link-check.outputs.log }}" >> $GITHUB_ENV
-      shell: bash

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,56 +30,81 @@ runs:
       shell: bash
       if: always()
       run: |
+        # Initialize variables
         has_errors=0
         current_file=""
         files=()
         all_links=()
         
+        # Process output line by line
         while IFS= read -r line; do
+            # Detect file header lines
             if [[ "$line" =~ ^FILE:[[:space:]]*(.+) ]]; then
                 current_file="${BASH_REMATCH[1]}"
                 files+=("$current_file")
             
-            elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+) ]]; then
+            # Detect broken link lines - extract URL, status code, and error message
+            elif [[ "$line" =~ ^[[:space:]]*\[✖\]\ ([^[:space:]]+).*Status:\ ([0-9]+)(.*)$ ]]; then
                 url="${BASH_REMATCH[1]}"
                 status="${BASH_REMATCH[2]}"
-                link_str="$url (Status: $status)"
+                error_msg="${BASH_REMATCH[3]}"
                 
+                # Clean up error message (trim leading/trailing whitespace)
+                error_msg=$(echo "$error_msg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+                
+                # Add to links array (format: file|url|status|error)
                 if [ -n "$current_file" ]; then
-                    all_links+=("${current_file}|${link_str}")
+                    all_links+=("${current_file}|${url}|${status}|${error_msg}")
                     has_errors=1
                 fi
             fi
         done <<< "$MLC_OUTPUT"
         
-        # 输出结论
+        # Output final conclusion
         if [ $has_errors -eq 0 ]; then
-            echo "All links are valid"
+            echo "✅ All links are valid"
             exit 0
         fi
         
-        echo "Found broken links"
+        echo "❌ Found broken links"
         echo
         echo "===== DETAILS ====="
         
+        # Remove duplicate files
         unique_files=($(printf "%s\n" "${files[@]}" | sort -u))
         
+        # Remove duplicate links
         unique_links=($(printf "%s\n" "${all_links[@]}" | sort -u))
         
+        # Output error details
         for file in "${unique_files[@]}"; do
             file_links=()
             for link in "${unique_links[@]}"; do
                 if [[ "$link" == "${file}|"* ]]; then
+                    # Extract link info (remove filename prefix)
                     link_only="${link#*|}"
                     file_links+=("$link_only")
                 fi
             done
             
+            # Output if file has broken links
             if [ ${#file_links[@]} -gt 0 ]; then
                 echo "File: $file"
                 
-                printf "  %s\n" "${file_links[@]}" | sort -u
+                # Output each broken link with details
+                for link_info in "${file_links[@]}"; do
+                    # Split link info into components
+                    IFS='|' read -r url status error_msg <<< "$link_info"
+                    
+                    # Format output with error message if present
+                    if [ -n "$error_msg" ]; then
+                        echo "  $url (Status: $status): $error_msg"
+                    else
+                        echo "  $url (Status: $status)"
+                    fi
+                done
                 
+                # Add link count
                 echo "  → Found ${#file_links[@]} broken link(s)"
                 echo
             fi

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -24,51 +24,32 @@ runs:
         max-depth: -1
         use-verbose-mode: 'yes'
         base-branch: 'gh-pages'
-        
-    - name: Summarize failed links
-      shell: bash
+        output-format: json
+        output-file: link-results.json
+
+    - name: Show error links summary
+      if: always()
       run: |
-        # Function to summarize failed links from the previous step output
-        summarize_failures() {
-          echo ""
-          echo "=========================================="
-          echo "FAILED LINKS SUMMARY"
-          echo "=========================================="
-          
-          # Get the output from the previous step (markdown link check)
-          # We'll parse the logs to find failed links
-          local failed_links=()
-          local failed_files=()
-          local total_failures=0
-          
-          # Look for common failure patterns in the logs
-          # This will capture the output from the markdown-link-check action
-          if [ -f "$GITHUB_STEP_SUMMARY" ]; then
-            # Try to read from step summary if available
-            while IFS= read -r line; do
-              if [[ "$line" =~ ✗ ]] || [[ "$line" =~ ERROR ]] || [[ "$line" =~ FAIL ]] || [[ "$line" =~ "HTTP [^2]" ]]; then
-                failed_links+=("$line")
-                ((total_failures++))
-              fi
-            done < "$GITHUB_STEP_SUMMARY"
-          fi
-          
-          # Also check for failures in the action output
-          # The markdown-link-check action typically outputs failures to stderr
-          if [ $total_failures -eq 0 ]; then
-            echo "Note: Detailed failure information should be visible in the markdown link check step above."
-            echo "Look for lines marked with ✗, ERROR, FAIL, or non-200 HTTP status codes."
-          else
-            echo "Total failures found: $total_failures"
-            echo ""
-            echo "Failed links:"
-            printf '  %s\n' "${failed_links[@]}"
-          fi
-          
-          echo ""
-          echo "For detailed failure information, check the 'Run markdown link check' step above."
-        }
+        echo -e "\n\n### Error Links Summary ###"        
+        grep -B 1 '"status": [^2]' link-results.json | \
+        awk '
+          /"link":/ {
+            gsub(/^[ \t]+"link": "/, "", $0);
+            gsub(/",?$/, "", $0);
+            link = $0
+          }
+          /"status":/ {
+            status = $2
+            sub(/,/, "", status);
+          }
+          /"filename":/ {
+            gsub(/^[ \t]+"filename": "/, "", $0);
+            gsub(/",?$/, "", $0);
+            if (link != "" && status != "" && $0 != "") {
+              printf "[%s] %-60s => %s\n", status, link, $0
+              link = ""; status = ""
+            }
+          }
+        ' | sort -u
         
-        # Run the summary
-        summarize_failures
-        
+        echo "### Total broken links: $(grep -c '"status": [^2]' link-results.json)"

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -34,7 +34,7 @@ runs:
         current_file=""
         files=()
         summaries=()
-        in_summary_section=0
+        in_summary_section=0 # 0: not in summary section, 1: in summary section
         
         # Process output line by line
         while IFS= read -r line; do
@@ -63,7 +63,7 @@ runs:
                     has_errors=1
                 fi
             fi
-        done <<< "$MLC_OUTPUT" # This is the output of the markdown link check action
+        done <<< "$MLC_OUTPUT" # The output of the markdown link check action
         
         # Output final conclusion
         if [ $has_errors -eq 0 ]; then
@@ -71,13 +71,13 @@ runs:
             exit 0
         fi
         
-        echo "=========== Found broken links ==========="        
+        echo "=========== Found error links ==========="        
         # Output error details
         for i in "${!files[@]}"; do
             filename="${files[$i]}"
             summary="${summaries[$i]}"
             
-            # Only show summaries that contain errors
+            # Only output summaries that contain errors
             if [[ "$summary" =~ ERROR: ]] || [[ "$summary" =~ \[✖\] ]]; then
                 echo "File: $filename"
                 # Preserve newlines in summary

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -1,0 +1,74 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Markdown Link Check'
+description: 'Check markdown links'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run markdown link check
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        max-depth: -1
+        use-verbose-mode: 'yes'
+        base-branch: 'gh-pages'
+        
+    - name: Summarize failed links
+      shell: bash
+      run: |
+        # Function to summarize failed links from the previous step output
+        summarize_failures() {
+          echo ""
+          echo "=========================================="
+          echo "FAILED LINKS SUMMARY"
+          echo "=========================================="
+          
+          # Get the output from the previous step (markdown link check)
+          # We'll parse the logs to find failed links
+          local failed_links=()
+          local failed_files=()
+          local total_failures=0
+          
+          # Look for common failure patterns in the logs
+          # This will capture the output from the markdown-link-check action
+          if [ -f "$GITHUB_STEP_SUMMARY" ]; then
+            # Try to read from step summary if available
+            while IFS= read -r line; do
+              if [[ "$line" =~ ✗ ]] || [[ "$line" =~ ERROR ]] || [[ "$line" =~ FAIL ]] || [[ "$line" =~ "HTTP [^2]" ]]; then
+                failed_links+=("$line")
+                ((total_failures++))
+              fi
+            done < "$GITHUB_STEP_SUMMARY"
+          fi
+          
+          # Also check for failures in the action output
+          # The markdown-link-check action typically outputs failures to stderr
+          if [ $total_failures -eq 0 ]; then
+            echo "Note: Detailed failure information should be visible in the markdown link check step above."
+            echo "Look for lines marked with ✗, ERROR, FAIL, or non-200 HTTP status codes."
+          else
+            echo "Total failures found: $total_failures"
+            echo ""
+            echo "Failed links:"
+            printf '  %s\n' "${failed_links[@]}"
+          fi
+          
+          echo ""
+          echo "For detailed failure information, check the 'Run markdown link check' step above."
+        }
+        
+        # Run the summary
+        summarize_failures
+        

--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -30,6 +30,8 @@ runs:
       shell: bash
       if: always()
       run: |
+        set -e
+        
         has_errors=0
         current_file=""
         files=()


### PR DESCRIPTION
Create custom markdown list check action, since

1. https://github.com/gaurav-nelson/github-action-markdown-link-check has been deprecated. Changed to https://github.com/tcort/github-action-markdown-link-check
2. Output error items at the end of log for better readability. 

Test runs:
1. [found error links](https://github.com/YanxuanLiu/spark-rapids-common/actions/runs/17041482748/job/48306080190?pr=4#step:4:286)
2. [all links valid](https://github.com/YanxuanLiu/spark-rapids-common/actions/runs/17056868836/job/48356049241?pr=4#step:4:183)