### PR TITLE
markdown link check: replace v1 with sha

### DIFF
--- a/markdown-link-check/action.yml
+++ b/markdown-link-check/action.yml
@@ -52,7 +52,7 @@ runs:
   steps:
     - name: Run markdown link check
       id: markdown-link-check
-      uses: tcort/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@a800ad5f1c35bf61987946fd31c15726a1c9f2ba
       with:
         use-quiet-mode: ${{ inputs.use-quiet-mode }}
         use-verbose-mode: ${{ inputs.use-verbose-mode }}


### PR DESCRIPTION
Replace `v1` with `sha`, added `sha` to allowlist of NVIDIA org.

test run: https://github.com/YanxuanLiu/spark-rapids-common/actions/runs/17196497872/job/48779311786?pr=8#step:4:8