### PR TITLE
Add PR checklist validation to pr-description-check action

### DIFF
--- a/pr-description-check/action.yml
+++ b/pr-description-check/action.yml
@@ -55,7 +55,12 @@ runs:
             const response = await github.rest.repos.getContent({
               owner, repo, path: templatePath,
             });
-            templateContent = Buffer.from(response.data.content, 'base64').toString('utf-8');
+            // == null catches both null (file >1MB) and undefined (directory listing)
+            if (response.data.type !== 'file' || response.data.content == null) {
+              core.info(`"${templatePath}" is not a readable file, skipping checklist check.`);
+            } else {
+              templateContent = Buffer.from(response.data.content, 'base64').toString('utf-8');
+            }
           } catch (error) {
             if (error.status === 404) {
               core.info(`PR template not found at "${templatePath}", skipping checklist check.`);

--- a/pr-description-check/action.yml
+++ b/pr-description-check/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,41 +13,89 @@
 # limitations under the License.
 
 name: 'PR Description Check'
-description: 'check if comment exists in PR description'
+description: 'check if comment exists in PR description and checklist items are present'
 inputs:
   github-token:
     description: "github token"
     required: true
     type: string
+  template-path:
+    description: "path to the PR template file in the caller repo"
+    required: false
+    default: '.github/PULL_REQUEST_TEMPLATE.md'
 
 runs:
   using: "composite"
   steps:
-    - name: Get PR description
-      id: pr_description
+    - name: Check PR description and checklist
       uses: actions/github-script@v7
+      env:
+        TEMPLATE_PATH: ${{ inputs.template-path }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           const pr = context.payload.pull_request;
           const prBody = pr.body || '';
           const sha = pr.head.sha;
-          const hasComment = prBody.includes('<!--');
-          const state = hasComment ? 'failure' : 'success';
-          const description = hasComment
-            ? 'PR description contains comment in "<!--". Please remove the comment manually.'
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          const errors = [];
+          const failedChecks = [];
+
+          const hasComments = prBody.includes('<!--');
+          if (hasComments) {
+            errors.push('PR description contains comment in "<!--". Please remove the comment manually.');
+            failedChecks.push('has HTML comments');
+          }
+
+          const templatePath = process.env.TEMPLATE_PATH;
+          let templateContent = null;
+          try {
+            const response = await github.rest.repos.getContent({
+              owner, repo, path: templatePath,
+            });
+            templateContent = Buffer.from(response.data.content, 'base64').toString('utf-8');
+          } catch (error) {
+            if (error.status === 404) {
+              core.info(`PR template not found at "${templatePath}", skipping checklist check.`);
+            } else {
+              throw error;
+            }
+          }
+
+          if (templateContent !== null) {
+            const templateItems = [...templateContent.matchAll(/^- \[ \] (.+)$/gm)]
+              .map(m => m[1].trim());
+
+            if (templateItems.length > 0) {
+              const bodyItems = new Set(
+                [...prBody.matchAll(/^- \[[xX ]\] (.+)$/gm)].map(m => m[1].trim())
+              );
+              const missingItems = templateItems.filter(item => !bodyItems.has(item));
+              if (missingItems.length > 0) {
+                errors.push(
+                  `Missing ${missingItems.length} checklist item(s) from PR template:\n` +
+                  missingItems.map(i => `  - ${i}`).join('\n')
+                );
+                failedChecks.push('missing checklist items');
+              }
+            }
+          }
+
+          const failed = errors.length > 0;
+          const statusDesc = failed
+            ? `Failed: ${failedChecks.join(', ')}.`
             : 'PR description is valid.';
 
-          if (hasComment) {
-            core.setFailed(description);
+          if (failed) {
+            core.setFailed(errors.join('\n\n'));
           }
 
           await github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: sha,
-            state: state,
+            owner, repo, sha,
+            state: failed ? 'failure' : 'success',
             target_url: pr.html_url,
-            description: description.substring(0, 140),
+            description: statusDesc.substring(0, 140),
             context: 'PR Description'
           });


### PR DESCRIPTION
  Fix NVIDIA/spark-rapids#14457

  ## Summary

  Some checklist items may be unexpectedly removed from PR descriptions. This change extends the `pr-description-check` action to verify that all required checklist items from the repo's PR template are still present in the PR body.

  ## How it works

  1. Fetches `.github/PULL_REQUEST_TEMPLATE.md` from the caller repo via GitHub API at runtime
  2. Extracts all `- [ ]` checklist items from the template
  3. Verifies each item exists in the PR body (accepts `- [ ]`, `- [x]`, or `- [X]`)
  4. Reports missing items with a clear failure message

  ## Key design decisions

  - **No hardcoded checklist items** — reads the template dynamically via GitHub API, so the check auto-adapts when the template changes
  - **Single commit status** — both the HTML comment check and checklist check report under one `PR Description` status context
  - **Graceful fallbacks** — skips silently if the template file doesn't exist (404) or has no checklist items; re-throws on unexpected API errors (auth,
  rate limit, 500)
  - **Configurable template path** — new optional `template-path` input (defaults to `.github/PULL_REQUEST_TEMPLATE.md`)
  - **Backward compatible** — no changes required in caller repos; existing workflows pick this up automatically

### Verified in forked repos

Has HTML comments, missing checklist items.
<img width="500" height="50" alt="image" src="https://github.com/user-attachments/assets/0c8a87bc-e19b-427a-9b70-62d535f6e59f" />

Has HTML comments only,
<img width="400" height="40" alt="image" src="https://github.com/user-attachments/assets/3745fc2e-fb20-4e2f-9966-a3708e2249e2" />

Missing checklist items only,
<img width="400" height="40" alt="image" src="https://github.com/user-attachments/assets/279251b1-2d42-4db5-b573-24a7a3c3157b" />

Passed,
<img width="400" height="50" alt="image" src="https://github.com/user-attachments/assets/5868a304-76c8-4865-a0ce-245d88bec2fe" />

No template,
<img width="600" height="80" alt="image" src="https://github.com/user-attachments/assets/7c2c0966-2e53-43c0-9ff2-5c3d0272af59" />

