### PR TITLE
Fix PyGithub Auth.Token usage for newer API

### DIFF
--- a/signoff-check/signoff-check
+++ b/signoff-check/signoff-check
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/signoff-check/signoff-check
+++ b/signoff-check/signoff-check
@@ -25,13 +25,13 @@ import re
 import sys
 from argparse import ArgumentParser
 
-from github import Github
+from github import Auth, Github
 
 SIGNOFF_REGEX = re.compile('Signed-off-by:')
 
 
 def signoff(token: str, owner: str, repo_name: str, pull_number: int):
-    gh = Github(token, per_page=100, user_agent='signoff-check', verify=True)
+    gh = Github(auth=Auth.Token(token), per_page=100, user_agent='signoff-check', verify=True)
     pr = gh.get_repo(f"{owner}/{repo_name}").get_pull(pull_number)
     for c in pr.get_commits():
         if SIGNOFF_REGEX.search(c.commit.message):


### PR DESCRIPTION
Fixing 
/signoff-check:34: DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
Noticed during https://github.com/NVIDIA/spark-rapids/pull/14531