### PR TITLE
Update check_main to true as default

### DIFF
--- a/license-header-check/action.yml
+++ b/license-header-check/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ inputs:
     description: "check main branch or not"
     required: false
     type: boolean
-    default: false
+    default: true
 
 runs:
   using: "composite"


### PR DESCRIPTION
Fixes #57  

Changed check_main default from false to true so license header validation runs on all PRs, including those targeting the main branch. Previously these were skipped by default.


