### PR TITLE
Set gh-pages Roadmap from download page

### DIFF
--- a/add-to-project/add_to_project.py
+++ b/add-to-project/add_to_project.py
@@ -37,6 +37,9 @@ ROADMAP_REPOSITORIES = {
 VERSION_PATTERN = re.compile(
     r"^(\d{2}\.(?:0[1-9]|1[0-2]))(?:\.\d+)*(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$"
 )
+GH_PAGES_VERSION_PATTERN = re.compile(
+    r"^## Release v(\d{2}\.(?:0[1-9]|1[0-2]))\.\d+[ \t]*$", re.MULTILINE
+)
 
 
 class AutomationError(Exception):
@@ -145,6 +148,16 @@ def extract_project_version(pom_xml):
             f"The project version {raw_version!r} is not an unambiguous YY.MM release."
         )
     return match.group(1)
+
+
+def extract_gh_pages_version(download_page):
+    """Return the YY.MM release from the download page's release heading."""
+    versions = GH_PAGES_VERSION_PATTERN.findall(download_page)
+    if len(versions) != 1:
+        raise AutomationError(
+            "docs/download.md must contain exactly one '## Release vYY.MM.x' heading."
+        )
+    return versions[0]
 
 
 def get_project(client, project_url, content_id):
@@ -305,7 +318,7 @@ def set_roadmap(client, project_id, item_id, field_id, option_id):
         raise AutomationError("GitHub did not confirm the Roadmap update.")
 
 
-def read_target_pom(client, repository, pull_request):
+def read_target_version(client, repository, pull_request):
     base_ref = require(
         dig(pull_request, "base", "ref"), "The pull request target branch is missing."
     )
@@ -314,19 +327,26 @@ def read_target_pom(client, repository, pull_request):
         "The pull request merged result SHA is missing.",
     )
 
-    pom = client.get(
-        f"repos/{repository}/contents/pom.xml", {"ref": merge_sha}
-    )
-    if not isinstance(pom, dict):
-        raise AutomationError("The target branch root pom.xml could not be read.")
-    content = pom.get("content")
-    if pom.get("type") != "file" or pom.get("encoding") != "base64" or not content:
-        raise AutomationError("The target branch root pom.xml could not be read.")
+    is_gh_pages = repository == "NVIDIA/cudf-spark" and base_ref == "gh-pages"
+    path = "docs/download.md" if is_gh_pages else "pom.xml"
+    source = client.get(f"repos/{repository}/contents/{path}", {"ref": merge_sha})
+    if (
+        not isinstance(source, dict)
+        or source.get("type") != "file"
+        or source.get("encoding") != "base64"
+        or not source.get("content")
+    ):
+        raise AutomationError(f"The target branch {path} could not be read.")
     try:
-        pom_xml = base64.b64decode("".join(content.split()), validate=True).decode()
+        encoded = "".join(source["content"].split())
+        text = base64.b64decode(encoded, validate=True).decode()
     except (AttributeError, binascii.Error, UnicodeError) as error:
-        raise AutomationError("The target branch pom.xml content is invalid.") from error
-    return base_ref, merge_sha, pom_xml
+        raise AutomationError(f"The target branch {path} content is invalid.") from error
+
+    extract_version = (
+        extract_gh_pages_version if is_gh_pages else extract_project_version
+    )
+    return base_ref, merge_sha, extract_version(text), path
 
 
 def populate_roadmap(client, repository, project, item, pull_request):
@@ -341,8 +361,9 @@ def populate_roadmap(client, repository, project, item, pull_request):
         print(f"Roadmap is already set to {current.get('name')!r}; preserving it.")
         return
 
-    base_ref, merge_sha, pom_xml = read_target_pom(client, repository, pull_request)
-    roadmap = extract_project_version(pom_xml)
+    base_ref, merge_sha, roadmap, source = read_target_version(
+        client, repository, pull_request
+    )
     options = field.get("options") if isinstance(field.get("options"), list) else []
     matches = [option for option in options if option.get("name") == roadmap]
     if len(matches) != 1:
@@ -366,7 +387,7 @@ def populate_roadmap(client, repository, project, item, pull_request):
         require(matches[0].get("id"), "Roadmap option ID is missing."),
     )
     print(
-        f"Set Roadmap to {roadmap!r} from pom.xml on merged target branch "
+        f"Set Roadmap to {roadmap!r} from {source} on merged target branch "
         f"{base_ref} ({merge_sha})."
     )
 


### PR DESCRIPTION
## Summary

- derive the Roadmap for `cudf-spark` `gh-pages` PRs from the merged `docs/download.md` release heading
- keep using `pom.xml` for all other target branches
- preserve existing Roadmap values and fail on missing or ambiguous versions

## Testing

- Python 3.9 and 3.14 regression tests
- `python3 -m py_compile add-to-project/add_to_project.py`
- `git diff --check`
- verified the current `gh-pages` page resolves to `26.08`